### PR TITLE
Added missing class names to otp_new

### DIFF
--- a/styles/prosilver/template/tfa_otp_ucp_new.html
+++ b/styles/prosilver/template/tfa_otp_ucp_new.html
@@ -10,7 +10,7 @@
             {{ S_HIDDEN_FIELDS }}
             {{ S_HIDDEN_FIELDS_MODULE }}
             <br />
-            <label for="otp">{{ lang('TFA_OTP_KEY') ~ lang('COLON') }}</label> <input type="text" name="register" id="otp" />
+            <label for="otp">{{ lang('TFA_OTP_KEY') ~ lang('COLON') }}</label> <input type="text" name="register" id="otp" class="inputbox autowidth" />
             <br />
             <input type="hidden" name="md" value="{{ lang('TFA_NEW') }}" />
             <input type="submit" name="submit" id="add_key" value="{{ lang('TFA_ADD_KEY') }}" class="button1"  />


### PR DESCRIPTION
Added missing class names for text boxes to be styled appropriately if user has a theme that changes the colour of the inputbox background.
